### PR TITLE
Refactor dashboard data flow and sidebar

### DIFF
--- a/app/achievements/page.tsx
+++ b/app/achievements/page.tsx
@@ -26,7 +26,7 @@ export default async function AchievementsPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="flex flex-1">
-        <Sidebar currentPage="achievements" setCurrentPage={() => {}} />
+        <Sidebar currentPage="achievements" />
         <main className="flex-1 lg:ml-0">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             <AchievementsPageComponent />

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -26,7 +26,7 @@ export default async function CommunityPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="flex flex-1">
-        <Sidebar currentPage="community" setCurrentPage={() => {}} />
+        <Sidebar currentPage="community" />
         <main className="flex-1 lg:ml-0">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             <CommunityPageComponent />

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -1,24 +1,14 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { useMemo } from 'react';
 import { Sidebar } from '@/components/layout/sidebar';
 import { Footer } from '@/components/layout/footer';
 import StatsOverview from '@/components/dashboard/stats-overview';
-import { createClient } from '@/lib/supabase/client';
 import ModuleCard from '@/components/dashboard/module-card';
 import { Header } from '@/components/layout/header';
 import { useRouter } from 'next/navigation';
 
-// Type definitions for better type safety
-export type Lesson = {
-  id: string;
-  title: string;
-  description: string | null;
-  duration_minutes: number;
-  sort_order: number;
-  core_concepts?: string[];
-};
-
+export type Lesson = { id: string };
 export type Module = {
   id: string;
   title: string;
@@ -31,113 +21,43 @@ export type Module = {
   rating: number;
   students_enrolled: number;
   is_locked: boolean;
-  sort_order: number;
+  sort_order: number | null;
   lessons: Lesson[];
 };
 
 type CategoryMap = Record<string, string>;
+type ProgressMap = Record<string, number>;
 
 export type DashboardClientProps = {
-  modules: Module[];
-  completedLessonIds: Set<string>;
-  userId: string;
   profile: any;
+  activeModules: Module[];
+  nextModules: Module[];
+  allModules: Module[];
   categories: CategoryMap;
+  userProgress: ProgressMap;
+  userId: string;
 };
 
-export default function DashboardClient({ 
-  modules, 
-  completedLessonIds: initialCompletedLessons,
-  userId,
+export default function DashboardClient({
   profile,
-  categories
+  activeModules,
+  nextModules,
+  allModules,
+  categories,
+  userProgress,
+  userId
 }: DashboardClientProps) {
-  const [completedLessons, setCompletedLessons] = useState<Set<string>>(initialCompletedLessons);
   const router = useRouter();
-  const supabase = createClient();
-  
-  // Calculate aggregated stats
-  const stats = useMemo(() => {
-    const totalLessons = modules.reduce((sum, mod) => sum + mod.lessons.length, 0);
-    const completedCount = completedLessons.size;
-    const completionRate = totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0;
-    
-    return {
-      totalLessons,
-      completedLessons: completedCount,
-      completionRate,
-      totalModules: modules.length,
-      completedModules: modules.filter(mod => 
-        mod.lessons.every(lesson => completedLessons.has(lesson.id))
-      ).length,
-    };
-  }, [modules, completedLessons]);
 
-  // Start a module and navigate to its lessons
-  const handleStartModule = useCallback((module: Module) => {
+  const handleStartModule = (module: Module) => {
     router.push(`/dashboard/modules/${module.id}`);
-  }, [router]);
-
-  // Mark a lesson as complete
-  const handleLessonComplete = useCallback(async (lessonId: string, moduleId: string) => {
-    try {
-      // Optimistically update UI
-      setCompletedLessons(prev => new Set([...prev, lessonId]));
-      
-      // Persist to database
-      const { error } = await supabase
-        .from('user_lesson_completions')
-        .upsert({
-          user_id: userId,
-          lesson_id: lessonId,
-          module_id: moduleId,
-          completed_at: new Date().toISOString(),
-          time_spent_minutes: 0 // This could be tracked more accurately
-        });
-        
-      if (error) {
-        console.error('Error saving lesson completion:', error);
-        // Revert optimistic update if save fails
-        setCompletedLessons(prev => {
-          const newSet = new Set([...prev]);
-          newSet.delete(lessonId);
-          return newSet;
-        });
-      } else {
-        // Refresh server data to ensure everything is in sync
-        router.refresh();
-      }
-    } catch (err) {
-      console.error('Error in lesson completion:', err);
-    }
-  }, [supabase, userId, router]);
-  
-  // Group modules by category for better organization
-  const modulesByCategory = useMemo(() => {
-    return modules.reduce((acc, module) => {
-      const categoryId = module.category_id || 'uncategorized';
-      const categoryName = categories[categoryId] || 'Uncategorized';
-      
-      if (!acc[categoryName]) {
-        acc[categoryName] = [];
-      }
-      acc[categoryName].push(module);
-      return acc;
-    }, {} as Record<string, Module[]>);
-  }, [modules, categories]);
-
-  // Calculate total curriculum hours
-  const totalHours = useMemo(() => {
-    return Math.round(
-      modules.reduce((total, module) => total + module.estimated_time_minutes, 0) / 60
-    );
-  }, [modules]);
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="flex flex-1">
-        <Sidebar currentPage="dashboard" setCurrentPage={() => {}} />
+        <Sidebar currentPage="dashboard" />
         <main className="flex-1 lg:ml-0">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             {/* Welcome Section */}
@@ -147,45 +67,60 @@ export default function DashboardClient({
                   Welcome back, {profile?.name || 'Learner'}! 👋
                 </h1>
                 <p className="text-blue-100 text-lg">
-                  Ready to continue your learning journey? Let's master the fundamentals of building great products!
+                  {activeModules.length > 0
+                    ? "Let's pick up where you left off."
+                    : 'Ready to start your learning journey?'}
                 </p>
               </div>
             </div>
 
-            {/* Stats Overview */}
-            <div className="mb-8">
-              <StatsOverview stats={stats} />
-            </div>
-
-            {/* Modules by Category */}
-            <div className="space-y-12">
-              {Object.entries(modulesByCategory).map(([category, modulesInCategory]) => (
-                <div key={category} className="space-y-6">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h2 className="text-2xl font-bold text-gray-900">{category}</h2>
-                    </div>
-                  </div>
-                  
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    {modulesInCategory.map(module => (
-                      <ModuleCard 
-                        key={module.id}
-                        module={module}
-                        onStartModule={() => handleStartModule(module)}
-                        completedLessons={completedLessons}
-                      />
-                    ))}
-                  </div>
+            {/* Section 1: Continue Learning */}
+            {activeModules.length > 0 && (
+              <div className="mb-12">
+                <h2 className="text-2xl font-bold text-gray-900 mb-4">Continue Learning</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {activeModules.map(module => (
+                    <ModuleCard
+                      key={module.id}
+                      module={module}
+                      onStartModule={() => handleStartModule(module)}
+                      progress={userProgress[module.id] || 0}
+                    />
+                  ))}
                 </div>
-              ))}
-            </div>
+              </div>
+            )}
 
-            {/* Overall Curriculum Stats */}
-            <div className="mt-8 text-center">
-              <p className="text-gray-500">
-                {modules.length} modules • {totalHours} hours total • {stats.completionRate}% complete
-              </p>
+            {/* Section 2: Next Up For You */}
+            {nextModules.length > 0 && (
+              <div className="mb-12">
+                <h2 className="text-2xl font-bold text-gray-900 mb-4">Next Up For You</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {nextModules.map(module => (
+                    <ModuleCard
+                      key={module.id}
+                      module={module}
+                      onStartModule={() => handleStartModule(module)}
+                      progress={0}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Section 3: Explore All Modules */}
+            <div className="mb-12">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4">Explore All Modules</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {allModules.map(module => (
+                  <ModuleCard
+                    key={module.id}
+                    module={module}
+                    onStartModule={() => handleStartModule(module)}
+                    progress={userProgress[module.id] || 0}
+                  />
+                ))}
+              </div>
             </div>
           </div>
         </main>

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -26,7 +26,7 @@ export default async function HelpPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="flex flex-1">
-        <Sidebar currentPage="help" setCurrentPage={() => {}} />
+        <Sidebar currentPage="help" />
         <main className="flex-1 lg:ml-0">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             <HelpPageComponent />

--- a/app/modules/page.tsx
+++ b/app/modules/page.tsx
@@ -26,7 +26,7 @@ export default async function ModulesPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="flex flex-1">
-        <Sidebar currentPage="modules" setCurrentPage={() => {}} />
+        <Sidebar currentPage="modules" />
         <main className="flex-1 lg:ml-0">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             <ModulesPageComponent />

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -26,7 +26,7 @@ export default async function ProgressPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="flex flex-1">
-        <Sidebar currentPage="progress" setCurrentPage={() => {}} />
+        <Sidebar currentPage="progress" />
         <main className="flex-1 lg:ml-0">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             <ProgressPageComponent />

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -26,7 +26,7 @@ export default async function SchedulePage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="flex flex-1">
-        <Sidebar currentPage="schedule" setCurrentPage={() => {}} />
+        <Sidebar currentPage="schedule" />
         <main className="flex-1 lg:ml-0">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             <SchedulePageComponent />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -26,7 +26,7 @@ export default async function SettingsPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="flex flex-1">
-        <Sidebar currentPage="settings" setCurrentPage={() => {}} />
+        <Sidebar currentPage="settings" />
         <main className="flex-1 lg:ml-0">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
             <SettingsPageComponent />

--- a/components/dashboard/module-card.tsx
+++ b/components/dashboard/module-card.tsx
@@ -12,21 +12,23 @@ import { Module } from '@/app/dashboard/DashboardClient';
 interface ModuleCardProps {
   module: Module;
   onStartModule: () => void;
-  completedLessons: Set<string>;
+  progress?: number;
+  completedLessons?: Set<string>;
 }
 
-export default function ModuleCard({ module, onStartModule, completedLessons }: ModuleCardProps) {
+export default function ModuleCard({ module, onStartModule, progress: progressProp, completedLessons }: ModuleCardProps) {
   const [isHovered, setIsHovered] = useState(false);
   
   // Calculate progress based on completed lessons
   const totalLessons = module.lessons?.length || 0;
-  const completedInThisModule = module.lessons?.filter(lesson => 
-    completedLessons.has(lesson.id)
+  const completedInThisModule = module.lessons?.filter(lesson =>
+    completedLessons?.has(lesson.id)
   ).length || 0;
-  
-  const progress = totalLessons > 0 ? Math.round((completedInThisModule / totalLessons) * 100) : 0;
-  const isCompleted = totalLessons > 0 && completedInThisModule === totalLessons;
-  const isStarted = completedInThisModule > 0;
+
+  const computedProgress = totalLessons > 0 ? Math.round((completedInThisModule / totalLessons) * 100) : 0;
+  const progress = progressProp !== undefined ? progressProp : computedProgress;
+  const isCompleted = progress === 100;
+  const isStarted = progress > 0;
 
   const getDifficultyColor = (difficulty: string) => {
     switch (difficulty) {

--- a/components/dashboard/modules-grid.tsx
+++ b/components/dashboard/modules-grid.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { ModuleCard } from './module-card';
+import ModuleCard from './module-card';
 import { useAppStore } from '@/lib/store-db';
 import { Module } from '@/lib/services/content-service';
 

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, Dispatch, SetStateAction } from 'react';
+import { useState } from 'react';
 import { 
   Home, 
   BookOpen, 
@@ -33,19 +33,14 @@ const navigationItems = [
 
 interface SidebarProps {
   currentPage: string;
-  setCurrentPage: Dispatch<SetStateAction<string>>;
 }
 
-export function Sidebar({ currentPage, setCurrentPage }: SidebarProps) {
+export function Sidebar({ currentPage }: SidebarProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = usePathname(); // Get current pathname
   const router = useRouter(); // Get router for navigation
   // Use the session from SessionProvider instead of auth context
 
-  const handleNavigation = (itemId: string) => {
-    setCurrentPage(itemId);
-    setSidebarOpen(false);
-  };
 
   return (
     <>


### PR DESCRIPTION
## Summary
- overhaul dashboard server logic to pre-filter modules
- simplify Dashboard client with focused sections
- drop unused `setCurrentPage` prop from Sidebar and pages
- adjust ModuleCard to accept progress prop
- fix ModulesGrid import

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68655510505c8330ba13b01cb442c3fd