### PR TITLE
Fix module start handler

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -83,7 +83,7 @@ export default function DashboardClient({
                     <ModuleCard
                       key={module.id}
                       module={module}
-                      onStartModule={() => handleStartModule(module)}
+                      onStartModule={handleStartModule}
                       progress={userProgress[module.id] || 0}
                     />
                   ))}
@@ -100,7 +100,7 @@ export default function DashboardClient({
                     <ModuleCard
                       key={module.id}
                       module={module}
-                      onStartModule={() => handleStartModule(module)}
+                      onStartModule={handleStartModule}
                       progress={0}
                     />
                   ))}
@@ -116,7 +116,7 @@ export default function DashboardClient({
                   <ModuleCard
                     key={module.id}
                     module={module}
-                    onStartModule={() => handleStartModule(module)}
+                    onStartModule={handleStartModule}
                     progress={userProgress[module.id] || 0}
                   />
                 ))}

--- a/components/dashboard/module-card.tsx
+++ b/components/dashboard/module-card.tsx
@@ -11,7 +11,7 @@ import { Module } from '@/app/dashboard/DashboardClient';
 
 interface ModuleCardProps {
   module: Module;
-  onStartModule: () => void;
+  onStartModule: (module: Module) => void;
   progress?: number;
   completedLessons?: Set<string>;
 }
@@ -59,7 +59,7 @@ export default function ModuleCard({ module, onStartModule, progress: progressPr
       )}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      onClick={() => !module.is_locked && onStartModule()}
+      onClick={() => !module.is_locked && onStartModule(module)}
     >
       <div className="relative">
         <img
@@ -182,7 +182,7 @@ export default function ModuleCard({ module, onStartModule, progress: progressPr
           disabled={module.is_locked}
           onClick={(e) => {
             e.stopPropagation();
-            if (!module.is_locked) onStartModule();
+            if (!module.is_locked) onStartModule(module);
           }}
         >
           {module.is_locked ? (


### PR DESCRIPTION
## Summary
- fix missing module argument when starting modules
- update DashboardClient to pass handler directly

## Testing
- `npm run lint` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686567219d7083308fe4ed746494fc16